### PR TITLE
서버 아키텍처 구조 변경, ClientResponseParser의 의존관계를 SocketHandler에 한정

### DIFF
--- a/cm/src/main/java/distributed/cm/server/BoardManager.java
+++ b/cm/src/main/java/distributed/cm/server/BoardManager.java
@@ -5,9 +5,7 @@ import distributed.cm.server.repository.*;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
-import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 @Slf4j

--- a/cm/src/main/java/distributed/cm/server/ClientMessageResponser.java
+++ b/cm/src/main/java/distributed/cm/server/ClientMessageResponser.java
@@ -1,5 +1,7 @@
 package distributed.cm.server;
 
+import distributed.cm.server.repository.SessionRepository;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import org.springframework.web.socket.TextMessage;
@@ -9,9 +11,16 @@ import java.io.IOException;
 import java.util.List;
 
 @Slf4j
+@RequiredArgsConstructor
 @Component
 public class ClientMessageResponser {
-    public void sendMessageAllSocket(String message, List<WebSocketSession> sessions, String exceptId) {
+
+    private final SessionRepository sessionRepository;
+
+    public void sendMessageAllSocket(String message, String exceptId) {
+        if (message == null) return;
+
+        List<WebSocketSession> sessions = sessionRepository.findAllSessions();
         for (WebSocketSession session : sessions) {
             try {
                 if(session.getId().equals(exceptId)) continue;
@@ -23,6 +32,7 @@ public class ClientMessageResponser {
     }
 
     public void sendMessageSocket(String message, WebSocketSession session) throws IOException {
+        if (message == null) return;
         session.sendMessage(new TextMessage(message));
     }
 }

--- a/cm/src/main/java/distributed/cm/server/handler/EntrySocketHandler.java
+++ b/cm/src/main/java/distributed/cm/server/handler/EntrySocketHandler.java
@@ -1,7 +1,5 @@
 package distributed.cm.server.handler;
 
-import distributed.cm.server.BoardManager;
-import distributed.cm.server.ClientMessageResponser;
 import distributed.cm.server.domain.User;
 import distributed.cm.server.parser.ClientResponseParser;
 import distributed.cm.server.repository.SessionRepository;
@@ -12,8 +10,6 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.socket.WebSocketSession;
 
 import java.io.IOException;
-import java.util.List;
-import java.util.Map;
 
 @Slf4j
 @Component
@@ -22,23 +18,21 @@ public class EntrySocketHandler {
 
     private final SessionRepository sessionRepository;
     private final UserRepository userRepository;
-    private final ClientMessageResponser clientMessageResponser;
     private final ClientResponseParser clientResponseParser;
-    private final BoardManager boardManager;
 
     public void openSocketHandle(String sessionId, WebSocketSession session) throws IOException {
         //세션
         sessionRepository.saveSession(sessionId, session);
     }
 
-    public void closeSocketHandle(String sessionId, WebSocketSession session) throws IOException {
+    public String closeSocketHandle(String sessionId) throws IOException {
+        sessionRepository.removeSession(sessionId);
         User user = userRepository.findUserBySessionId(sessionId);
         if (user != null) {
             userRepository.removeUser(sessionId);
             String closeSocketMessage = clientResponseParser.createCloseSocketMessage(user.getUserId());
-            List<WebSocketSession> sessions = sessionRepository.findAllSessions();
-            clientMessageResponser.sendMessageAllSocket(closeSocketMessage, sessions, sessionId);
+            return closeSocketMessage;
         }
-        sessionRepository.removeSession(sessionId);
+        return null;
     }
 }

--- a/cm/src/main/java/distributed/cm/server/handler/RecieveMessageHandler.java
+++ b/cm/src/main/java/distributed/cm/server/handler/RecieveMessageHandler.java
@@ -2,46 +2,34 @@ package distributed.cm.server.handler;
 
 import distributed.cm.client.msg.*;
 import distributed.cm.server.BoardManager;
-import distributed.cm.server.ClientMessageResponser;
-import distributed.cm.server.domain.Draw;
 import distributed.cm.server.domain.User;
 import distributed.cm.server.parser.ClientRequestParser;
 import distributed.cm.server.parser.ClientResponseParser;
-import distributed.cm.server.repository.SessionRepository;
 import distributed.cm.server.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
-import org.springframework.web.socket.WebSocketSession;
 
 import java.io.IOException;
-import java.util.List;
-import java.util.Map;
 
 @Slf4j
 @Component
 @RequiredArgsConstructor
 public class RecieveMessageHandler {
-    private final SessionRepository sessionRepository;
     private final UserRepository userRepository;
     private final ClientRequestParser clientRequestParser;
-
     private final ClientResponseParser clientResponseParser;
-    private final ClientMessageResponser clientMessageResponser;
+
     private final BoardManager boardManager;
-    public void handle(String sessionId, String payload) throws IOException {
+    public String handle(String sessionId, String payload) throws IOException {
         //요청 메세지 파싱
         Message message = clientRequestParser.parse(payload);
-
-        //응답 메세지
-        List<WebSocketSession> sessions = sessionRepository.findAllSessions();
-        clientMessageResponser.sendMessageAllSocket(payload, sessions, sessionId);
-
         if (message instanceof DefaultMessage) {
             userEntryHandle(sessionId, (DefaultMessage) message);
         } else {
             drawMessageHandle((DrawMessage) message);
         }
+        return payload;
     }
 
     private void userEntryHandle(String sessionId, DefaultMessage message) throws IOException {

--- a/cm/src/main/java/distributed/cm/server/parser/ClientResponseParser.java
+++ b/cm/src/main/java/distributed/cm/server/parser/ClientResponseParser.java
@@ -3,13 +3,10 @@ package distributed.cm.server.parser;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import distributed.cm.client.msg.UserEntryMessage;
-import distributed.cm.server.domain.Draw;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
-import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 @Slf4j


### PR DESCRIPTION
소켓에 메세지를 보내는 역할을 SocketHandler로 한정